### PR TITLE
When comparing to entities, do not recurse via FK. Instead use the FK…

### DIFF
--- a/ormy/csv_query_engine.py
+++ b/ormy/csv_query_engine.py
@@ -132,5 +132,6 @@ class CsvQueryEngine(QueryEngine):
         for patch in entities_to_patch:
             setattr(patch, fk_object_field, cache[getattr(patch, fk_field)])
 
-        for c in fk_model.get_fk_columns():
-            self.load_fk_entities_work(c, new_entities, entity_cache)
+        if len(new_entities) > 0:
+            for c in fk_model.get_fk_columns():
+                self.load_fk_entities_work(c, new_entities, entity_cache)

--- a/ormy/model.py
+++ b/ormy/model.py
@@ -75,6 +75,8 @@ class Model(object):
 
     @classmethod
     def compare(cls, ent1, ent2):
+        if ent1 is ent2:
+            return True
         if not isinstance(ent1, Model):
             return False
         if type(ent1) != type(ent2):
@@ -82,12 +84,16 @@ class Model(object):
         for c in type(ent1).columns:
             if c.has_field(ent1) != c.has_field(ent2):
                 return False
+            # FK's must be checked before regular fields
+            if c.has_fk():
+                #  NOTE: What does it mean to have FKs not equal? Does that mean immediately that the two
+                #  objects are not equal? FKs must point to a unique row in the foreign table. But are we comparing
+                #  the rows or the content of the row for comparison?
+                #  ANSWER: FKs being different immediately returns False for the comparison because the FK is
+                #    referencing a different row. Even if all the other values are the same, the row (therefore
+                #    the entity) is a different instance.
+                return c.get_field(ent1) == c.get_field(ent2)
             if c.get_field(ent1) != c.get_field(ent2):
                 return False
-            if c.has_fk():
-                fk_ent1 = getattr(ent1, c.object_field)
-                fk_ent2 = getattr(ent2, c.object_field)
-                if not cls.compare(fk_ent1, fk_ent2):
-                    return False
 
         return True

--- a/ormy/query_engine.py
+++ b/ormy/query_engine.py
@@ -12,7 +12,7 @@ class Expr(ABC):
         self.right = None
 
     def __eq__(self, other) -> bool:
-        return isinstance(other, type(self))
+        return self is other or isinstance(other, type(self))
 
     def children(self, left, right=None):
         self.left = left

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -170,5 +170,8 @@ class TestModel:
 
         assert Model.compare(l1, l2)
 
-        l1.level2.level3.value = 1
+        l2.level2_id = 4
+        l2.level2.id = 4
+        l2.level2.level3_id = 5
+        l2.level2.level3.id = 5
         assert not Model.compare(l1, l2)


### PR DESCRIPTION
… id to compare. This avoids cycles in comparisons.