### PR TITLE
couple of fixes

### DIFF
--- a/ormy/column.py
+++ b/ormy/column.py
@@ -13,12 +13,13 @@ class PrimaryKey(object):
 class ForeignKey(object):
     # TODO: move field to the end of the param list and default to None. If not specified uses the same field name
     #   in the parent table.
-    def __init__(self, field: str, model: Type[Model]):
+    def __init__(self, field: str, model: Type[Model], **kwargs):
         # TODO: lookup foreign_key_name in model and confirm exists
         #    Also validate, somewhere else probably, that type of FK and key in FK model match.
         # NOTE: the FK doesn't have to reference the PK of the other table!
         self.field = field
         self.model = model
+        self.strict = kwargs.get('strict', True)
         # TODO: support nullable FKs? Interesting different constraints on nullable key:
         #   https://stackoverflow.com/questions/7573590/can-a-foreign-key-be-null-and-or-duplicate
         # I particularly like the reference to the oracle documentation

--- a/ormy/datatabase.py
+++ b/ormy/datatabase.py
@@ -81,6 +81,16 @@ class RecordLambdaNode(CodeQueryBase):
     def exec(self):
         return self.context.eval_query()
 
+    # noinspection PyPep8Naming
+    def AND(self):
+        self.child = AndNode(self.context)
+        return self.child
+
+    # noinspection PyPep8Naming
+    def OR(self):
+        self.child = OrNode(self.context)
+        return self.child
+
     def __str__(self):
         return 'rlambda(%s)' % self.func
 

--- a/ormy/query_engine.py
+++ b/ormy/query_engine.py
@@ -198,17 +198,11 @@ class WholeRecordExpr(OperandExpr):
         return super().__eq__(other)
 
 
-class RecordLambdaExpr(OperatorExpr):
+class RecordLambdaExpr(OperandExpr):
     def __init__(self, func):
         super().__init__()
         self.func = func
         self.left = WholeRecordExpr()
-
-    def precedence(self):
-        return 15
-
-    def operand_count(self):
-        return 0
 
     def __str__(self):
         return 'rlambda(%s)' % self.func

--- a/tests/test_csv_database.py
+++ b/tests/test_csv_database.py
@@ -108,6 +108,22 @@ class TestCsvDatabase:
         assert m1.int_col == 101 and m1.string_col == 'foobar2'
         assert m2.int_col == 102 and m2.string_col == 'foobar3'
 
+    def test_query_two_ands(self, tmpdir):
+        f1 = tmpdir.join(AllValueTypes.__csv_file__)
+        f1.write("""int_col,float_col,string_col,date_col
+100,1.00234,foobar1,2020-08-19 17:44:49.732176
+101,1.00234,foobar2,2020-08-19 17:44:49.732176
+102,1.00234,foobar3,2020-08-19 17:44:49.732176
+100,1.00234,foobar4,2020-08-19 17:44:49.732176
+""")
+        db = CsvDatabase(str(tmpdir))
+        data = db.query(AllValueTypes).field('int_col').flambda(lambda x: x == 100) \
+            .AND().rlambda(lambda rec: rec.string_col == 'foobar4') \
+            .AND().value(True).exec()
+        assert len(data) == 1
+        m = data[0]
+        assert m.int_col == 100 and m.string_col == 'foobar4'
+
     def test_multiple_fk_one_deep(self, tmpdir):
         db = CsvDatabase(str(tmpdir))
         f1 = tmpdir.join(ModelLevel2.__csv_file__)


### PR DESCRIPTION
- ForeignKey has a 'strict' boolean flag that allows the FK to not exist in the parent table. The object_field is merely set to None.
- Don't load the foreign key references if there are no entities already loaded (no child table no entities to patch).
- rlambda() is a operand since it doesn't consume any operands. flambda() is a operator (not changed in this commit because it's right) it does consume the field operand.
- Added test for *two* AND().
- fix linting warnings